### PR TITLE
2 small bugfixes

### DIFF
--- a/pyaes/blockfeeder.py
+++ b/pyaes/blockfeeder.py
@@ -167,7 +167,7 @@ def _feed_stream(feeder, in_stream, out_stream, block_size = BLOCK_SIZE):
     'Uses feeder to read and convert from in_stream and write to out_stream.'
 
     while True:
-        chunk = in_stream.read(BLOCK_SIZE)
+        chunk = in_stream.read(block_size)
         if not chunk:
             break
         converted = feeder.feed(chunk)

--- a/pyaes/util.py
+++ b/pyaes/util.py
@@ -57,4 +57,7 @@ def strip_PKCS7_padding(data):
     if pad > 16:
         raise ValueError("invalid padding byte")
 
-    return data[:-pad]
+    if pad is 0:
+        return data
+    else:
+        return data[:-pad]


### PR DESCRIPTION
I fixed two smaller issues: 

* The _feed_stream function effectively ignored the block_size argument
* If strip_PKCS7_padding detected zero padding bytes the function would return an empty string data[:-0] rather than the data itself

I tested extraction of 1.2 GB of encrypted data, which works fine now. Before the second fix I would always miss out on the last 16 bytes.

Cheers