### PR TITLE
Use relative imports during tests

### DIFF
--- a/tests/test-aes.py
+++ b/tests/test-aes.py
@@ -22,7 +22,8 @@
 
 
 import sys
-sys.path.append('../pyaes')
+sys.path.append('./')
+sys.path.append('../')
 
 from pyaes import *
 

--- a/tests/test-blockfeeder.py
+++ b/tests/test-blockfeeder.py
@@ -22,7 +22,8 @@
 
 
 import sys
-sys.path.append('../pyaes')
+sys.path.append('./')
+sys.path.append('../')
 
 import os
 import random

--- a/tests/test-util.py
+++ b/tests/test-util.py
@@ -22,7 +22,8 @@
 
 
 import sys
-sys.path.append('../pyaes')
+sys.path.append('./')
+sys.path.append('../')
 
 from pyaes.util import append_PKCS7_padding, strip_PKCS7_padding
 


### PR DESCRIPTION
Sometimes you're testing package not from ~/Projects/pyaes or something,
but from ~/Projects/python-pyaes. Let's allow people to rename a
project's top-level directory.

Also let's allow run tests from ./tests/ as well.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>