### PR TITLE
Support older Python 2.7 versions

### DIFF
--- a/pyaes/aes.py
+++ b/pyaes/aes.py
@@ -145,7 +145,7 @@ class AES(object):
         KC = len(key) // 4
 
         # Convert the key into ints
-        tk = [ struct.unpack('>i', key[i:i + 4])[0] for i in xrange(0, len(key), 4) ]
+        tk = [ struct.unpack('>i', bytes(key[i:i + 4]))[0] for i in xrange(0, len(key), 4) ]
 
         # Copy values into round key arrays
         for i in xrange(0, KC):


### PR DESCRIPTION
Python 2.7.2 and 2.7.3 struct.unpack() fail with:

    error: unpack requires a string argument of length 4

If key is passed in as a bytearray parameter, this is fine in later 2.7.x versions and Python 3.x. Casting as bytes() works for both Python 2.7.x and 3.x.

http://stackoverflow.com/questions/20612587/struct-unpack-with-bytearrays has more information