### PR TITLE
cleanup & test fix

### DIFF
--- a/pyaes/aes.py
+++ b/pyaes/aes.py
@@ -51,7 +51,6 @@
 # See the README.md for API details and general information.
 
 
-import copy
 import struct
 
 __all__ = ["AES", "AESModeOfOperationCTR", "AESModeOfOperationCBC", "AESModeOfOperationCFB",
@@ -74,7 +73,7 @@ def _concat_list(a, b):
 # Python 3 compatibility
 try:
     xrange
-except Exception:
+except NameError:
     xrange = range
 
     # Python 3 supports bytes, which is already an array of integers
@@ -221,7 +220,7 @@ class AES(object):
                         self.T3[(t[(i + s2) % 4] >>  8) & 0xFF] ^
                         self.T4[ t[(i + s3) % 4]        & 0xFF] ^
                         self._Ke[r][i])
-            t = copy.copy(a)
+            t = a[:]
 
         # The last round is special
         result = [ ]
@@ -255,7 +254,7 @@ class AES(object):
                         self.T7[(t[(i + s2) % 4] >>  8) & 0xFF] ^
                         self.T8[ t[(i + s3) % 4]        & 0xFF] ^
                         self._Kd[r][i])
-            t = copy.copy(a)
+            t = a[:]
 
         # The last round is special
         result = [ ]

--- a/pyaes/aes.py
+++ b/pyaes/aes.py
@@ -137,7 +137,7 @@ class AES(object):
             tk[0] ^= ((self.S[(tt >> 16) & 0xFF] << 24) ^
                       (self.S[(tt >>  8) & 0xFF] << 16) ^
                       (self.S[ tt        & 0xFF] <<  8) ^
-                       self.S[(tt >> 24) & 0xFF]        ^
+                       self.S[(tt >> 24)       ]        ^
                       (self.rcon[rconpointer] << 24))
             rconpointer += 1
 
@@ -154,7 +154,7 @@ class AES(object):
                 tk[KC // 2] ^= (self.S[ tt        & 0xFF]        ^
                                (self.S[(tt >>  8) & 0xFF] <<  8) ^
                                (self.S[(tt >> 16) & 0xFF] << 16) ^
-                               (self.S[(tt >> 24) & 0xFF] << 24))
+                               (self.S[(tt >> 24)       ] << 24))
 
                 for i in xrange(KC // 2 + 1, KC):
                     tk[i] ^= tk[i - 1]
@@ -171,7 +171,7 @@ class AES(object):
         for r in xrange(1, rounds):
             for j in xrange(0, 4):
                 tt = self._Kd[r][j]
-                self._Kd[r][j] = (self.U1[(tt >> 24) & 0xFF] ^
+                self._Kd[r][j] = (self.U1[(tt >> 24)       ] ^
                                   self.U2[(tt >> 16) & 0xFF] ^
                                   self.U3[(tt >>  8) & 0xFF] ^
                                   self.U4[ tt        & 0xFF])
@@ -192,7 +192,7 @@ class AES(object):
         # Apply round transforms
         for r in xrange(1, rounds):
             for i in xrange(0, 4):
-                a[i] = (self.T1[(t[ i          ] >> 24) & 0xFF] ^
+                a[i] = (self.T1[(t[ i          ] >> 24)       ] ^
                         self.T2[(t[(i + s1) % 4] >> 16) & 0xFF] ^
                         self.T3[(t[(i + s2) % 4] >>  8) & 0xFF] ^
                         self.T4[ t[(i + s3) % 4]        & 0xFF] ^
@@ -203,7 +203,7 @@ class AES(object):
         result = [ ]
         for i in xrange(0, 4):
             tt = self._Ke[rounds][i]
-            result.append((self.S[(t[ i           ] >> 24) & 0xFF] ^ (tt >> 24)) & 0xFF)
+            result.append((self.S[(t[ i          ] >> 24)       ] ^ (tt >> 24)) & 0xFF)
             result.append((self.S[(t[(i + s1) % 4] >> 16) & 0xFF] ^ (tt >> 16)) & 0xFF)
             result.append((self.S[(t[(i + s2) % 4] >>  8) & 0xFF] ^ (tt >>  8)) & 0xFF)
             result.append((self.S[ t[(i + s3) % 4]        & 0xFF] ^  tt       ) & 0xFF)
@@ -226,7 +226,7 @@ class AES(object):
         # Apply round transforms
         for r in xrange(1, rounds):
             for i in xrange(0, 4):
-                a[i] = (self.T5[(t[ i          ] >> 24) & 0xFF] ^
+                a[i] = (self.T5[(t[ i          ] >> 24)       ] ^
                         self.T6[(t[(i + s1) % 4] >> 16) & 0xFF] ^
                         self.T7[(t[(i + s2) % 4] >>  8) & 0xFF] ^
                         self.T8[ t[(i + s3) % 4]        & 0xFF] ^
@@ -237,7 +237,7 @@ class AES(object):
         result = [ ]
         for i in xrange(0, 4):
             tt = self._Kd[rounds][i]
-            result.append((self.Si[(t[ i           ] >> 24) & 0xFF] ^ (tt >> 24)) & 0xFF)
+            result.append((self.Si[(t[ i          ] >> 24)       ] ^ (tt >> 24)) & 0xFF)
             result.append((self.Si[(t[(i + s1) % 4] >> 16) & 0xFF] ^ (tt >> 16)) & 0xFF)
             result.append((self.Si[(t[(i + s2) % 4] >>  8) & 0xFF] ^ (tt >>  8)) & 0xFF)
             result.append((self.Si[ t[(i + s3) % 4]        & 0xFF] ^  tt       ) & 0xFF)

--- a/pyaes/blockfeeder.py
+++ b/pyaes/blockfeeder.py
@@ -21,8 +21,8 @@
 # THE SOFTWARE.
 
 
-from .aes import AESBlockModeOfOperation, AESSegmentModeOfOperation, AESStreamModeOfOperation
-from .util import append_PKCS7_padding, strip_PKCS7_padding, to_bufferable
+from pyaes.aes import AESBlockModeOfOperation, AESSegmentModeOfOperation, AESStreamModeOfOperation
+from pyaes.util import append_PKCS7_padding, strip_PKCS7_padding, to_bufferable
 
 
 # First we inject three functions to each of the modes of operations

--- a/pyaes/util.py
+++ b/pyaes/util.py
@@ -26,33 +26,16 @@
 # represent arbitrary binary data, we must use the "bytes" object. This method
 # ensures the object behaves as we need it to.
 
-def to_bufferable(binary):
-    return binary
-
-def _get_byte(c):
-    return ord(c)
-
-try:
-    xrange
-except NameError:
-
-    def to_bufferable(binary):
-        if isinstance(binary, bytes):
-            return binary
-        return bytes(ord(b) for b in binary)
-
-    def _get_byte(c):
-        return c
 
 def append_PKCS7_padding(data):
     pad = 16 - (len(data) % 16)
-    return data + to_bufferable(chr(pad) * pad)
+    return data + bytes([pad]) * pad
 
 def strip_PKCS7_padding(data):
     if len(data) % 16 != 0:
         raise ValueError("invalid length")
 
-    pad = _get_byte(data[-1])
+    pad = bytearray(data)[-1]
 
     if pad > 16:
         raise ValueError("invalid padding byte")

--- a/pyaes/util.py
+++ b/pyaes/util.py
@@ -34,7 +34,7 @@ def _get_byte(c):
 
 try:
     xrange
-except:
+except NameError:
 
     def to_bufferable(binary):
         if isinstance(binary, bytes):

--- a/tests/test-aes.py
+++ b/tests/test-aes.py
@@ -22,7 +22,7 @@
 
 
 import sys
-sys.path.append('../pyaes')
+sys.path.append('..')
 
 from pyaes import *
 
@@ -33,8 +33,6 @@ try:
     xrange
 except NameError:
     xrange = range
-else:
-    pass
 
 # compare against a known working implementation
 from Crypto.Cipher import AES as KAES
@@ -141,7 +139,7 @@ for mode in [ 'CBC', 'CTR',  'CFB', 'ECB', 'OFB' ]:
             tt_kdecrypt += time.time() - t0
 
             t0 = time.time()
-            dt2 = [aes2.decrypt(k) for k in kenc]
+            dt2 = [aes2.decrypt(k) for k in enc]
             tt_decrypt += time.time() - t0
 
             if plaintext != dt2:

--- a/tests/test-blockfeeder.py
+++ b/tests/test-blockfeeder.py
@@ -22,20 +22,18 @@
 
 
 import sys
-sys.path.append('../pyaes')
+sys.path.append('..')
 
 import os
 import random
 
 try:
-    from StringIO import StringIO
-except:
-    import io
-    StringIO = io.BytesIO
+    from StringIO import StringIO as BytesIO
+except ImportError:
+    from io import BytesIO
 
 import pyaes
 from pyaes.blockfeeder import Decrypter, Encrypter
-from pyaes import decrypt_stream, encrypt_stream
 from pyaes.util import to_bufferable
 
 
@@ -132,14 +130,14 @@ for mode_name in pyaes.AESModesOfOperation:
         kw['iv'] = os.urandom(16)
 
     moo = mode(**kw)
-    output = StringIO()
-    pyaes.encrypt_stream(moo, StringIO(plaintext), output)
+    output = BytesIO()
+    pyaes.encrypt_stream(moo, BytesIO(plaintext), output)
     output.seek(0)
     ciphertext = output.read()
 
     moo = mode(**kw)
-    output = StringIO()
-    pyaes.decrypt_stream(moo, StringIO(ciphertext), output)
+    output = BytesIO()
+    pyaes.decrypt_stream(moo, BytesIO(ciphertext), output)
     output.seek(0)
     decrypted = output.read()
 

--- a/tests/test-blockfeeder.py
+++ b/tests/test-blockfeeder.py
@@ -34,7 +34,6 @@ except ImportError:
 
 import pyaes
 from pyaes.blockfeeder import Decrypter, Encrypter
-from pyaes.util import to_bufferable
 
 
 key = os.urandom(32)
@@ -50,7 +49,7 @@ for mode_name in pyaes.AESModesOfOperation:
         kw['iv'] = os.urandom(16)
 
     encrypter = Encrypter(mode(**kw))
-    ciphertext = to_bufferable('')
+    ciphertext = b''
 
     # Feed the encrypter random number of bytes at a time
     index = 0
@@ -62,7 +61,7 @@ for mode_name in pyaes.AESModesOfOperation:
     ciphertext += encrypter.feed(None)
 
     decrypter = Decrypter(mode(**kw))
-    decrypted = to_bufferable('')
+    decrypted = b''
 
     # Feed the decrypter random number of bytes at a time
     index = 0
@@ -89,7 +88,7 @@ for mode_name in ['ecb', 'cbc']:
         kw['iv'] = os.urandom(16)
 
     encrypter = Encrypter(mode(**kw), padding = pyaes.PADDING_NONE)
-    ciphertext = to_bufferable('')
+    ciphertext = b''
 
     # Feed the encrypter random number of bytes at a time
     index = 0
@@ -104,7 +103,7 @@ for mode_name in ['ecb', 'cbc']:
         print('  failed to encrypt with correct padding')
 
     decrypter = Decrypter(mode(**kw), padding = pyaes.PADDING_NONE)
-    decrypted = to_bufferable('')
+    decrypted = b''
 
     # Feed the decrypter random number of bytes at a time
     index = 0

--- a/tests/test-util.py
+++ b/tests/test-util.py
@@ -22,19 +22,17 @@
 
 
 import sys
-sys.path.append('../pyaes')
+sys.path.append('..')
 
 from pyaes.util import append_PKCS7_padding, strip_PKCS7_padding
 
-byte = 'A'
+byte = b'A'
 
 # Python 3 compatibility
 try:
     xrange
-except Exception:
+except NameError:
     xrange = range
-    # convert sample byte to bytes type, so that data = byte * i yields bytes, not str
-    byte = bytes(byte, 'utf-8')
 
 for i in xrange(0, 17):
     data = byte * i


### PR DESCRIPTION
This PR include:

1. remove dependency on copy module which is unnecessary, that also allow pyaes run on micropython.
2. fix imports. for tests, correct path of import, use recommended absolute import to replace relative import, rename StringIO to BytesIO to fit real variable type.
3. remove ugly workaround for py2/3, replace with bytes/bytearray.
4. don't mask MSB, increase speed a little bit