### PR TITLE
fix PKCS7 padding verification

### DIFF
--- a/pyaes/util.py
+++ b/pyaes/util.py
@@ -54,7 +54,11 @@ def strip_PKCS7_padding(data):
 
     pad = _get_byte(data[-1])
 
-    if pad > 16:
+    if pad < 1 or pad > 16:
         raise ValueError("invalid padding byte")
+
+    for x in range(2, pad + 1):
+        if data[-x] != data[-1]:
+            raise ValueError("invalid PKCS7 padding")
 
     return data[:-pad]


### PR DESCRIPTION
PKCS7 padding is not properly verified, which may lead to incorrectly decrypted data being assumed valid. For more info see https://github.com/JoinMarket-Org/joinmarket/pull/191#issuecomment-131111979

Thanks to @AdamISZ for finding the bug!