### PR TITLE
Migrate to Setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 LONG_DESCRIPTION = '''A pure-Python implementation of the AES (FIPS-197)
 block-cipher algorithm and common modes of operation (CBC, CFB, CTR, ECB,


### PR DESCRIPTION
Python 3.12 has removed `distutils`.

Fedora is using this patch in the deployed version of this package.